### PR TITLE
Enable branch protection rules

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,17 +67,9 @@ jobs:
       - name: Push changelog
         uses: github-actions-x/commit@v2.9
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.RELEASE_DRAFTER_BOT }}
           push-branch: 'main'
-          commit-message: 'update changelog'
+          commit-message: 'Update changelog'
           force-add: 'true'
           files: CHANGELOG.rst changelogs/
-          name: 'Ansible devtools bot'
-          email: 'devtools@ansible.com'
           rebase: true
-
-      # do a second checkout to prevent race situation
-      # changelog gets updated but action works on old commit id
-      - uses: actions/checkout@v3.5.0
-        with:
-          ref: main

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -40,9 +40,9 @@ releases:
         - Switch to action low level command (https://github.com/ansible-collections/ansible.scm/pull/14)
         - Test (https://github.com/ansible-collections/ansible.scm/pull/34)
         - Updates necessary for passing tests (https://github.com/ansible-collections/ansible.scm/pull/61)
-        - '[pre-commit.ci] pre-commit autoupdate (https://github.com/ansible-collections/ansible.scm/pull/11)'
-        - '[pre-commit.ci] pre-commit autoupdate (https://github.com/ansible-collections/ansible.scm/pull/31)'
-        - '[pre-commit.ci] pre-commit autoupdate (https://github.com/ansible-collections/ansible.scm/pull/56)'
+        - "[pre-commit.ci] pre-commit autoupdate (https://github.com/ansible-collections/ansible.scm/pull/11)"
+        - "[pre-commit.ci] pre-commit autoupdate (https://github.com/ansible-collections/ansible.scm/pull/31)"
+        - "[pre-commit.ci] pre-commit autoupdate (https://github.com/ansible-collections/ansible.scm/pull/56)"
         - basic and priv (https://github.com/ansible-collections/ansible.scm/pull/28)
         - nolabel (https://github.com/ansible-collections/ansible.scm/pull/51)
         - test (https://github.com/ansible-collections/ansible.scm/pull/39)
@@ -65,4 +65,4 @@ releases:
       - 63.yaml
       - 64.yaml
       - 9.yaml
-    release_date: '2023-03-29'
+    release_date: "2023-03-29"


### PR DESCRIPTION
Use a PAT to enable branch protection rules. The PAT should allow the branch protection rules to be bypassed for the changelog commit.