### PR TITLE
Update to reflect ansible-core 2.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains the `ansible.scm` Ansible Collection.
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.9.10**.
+This collection has been tested against following Ansible versions: **>=2.12.0**.
 
 For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
 fully qualified collection name (for example, `cisco.ios.ios`).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: ">=2.9.10"
+requires_ansible: ">=2.12.0"


### PR DESCRIPTION
Due to the integration testing matrix beginning at python 3.9, declare support for only ansible-core 2.12 or later.