### PR TITLE
Format flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -39,11 +39,16 @@ extend-exclude =
 # IMPORTANT: avoid using ignore option, always use extend-ignore instead
 # Completely and unconditionally ignore the following errors:
 extend-ignore =
-  Q  # Safeguard neutering of flake8-quotes : https://github.com/zheller/flake8-quotes/issues/105
-  E203,  # annoy black by allowing white space before : https://github.com/psf/black/issues/315
-  F401,  # duplicate of pylint W0611 (unused-import)
-  F821,  # duplicate of pylint E0602 (undefined-variable)
-  F841,  # duplicate of pylint W0612 (unused-variable)
+  # Safeguard neutering of flake8-quotes : https://github.com/zheller/flake8-quotes/issues/105
+  Q,
+  # annoy black by allowing white space before : https://github.com/psf/black/issues/315
+  E203,
+  # duplicate of pylint W0611 (unused-import)
+  F401,
+  # duplicate of pylint E0602 (undefined-variable)
+  F821,
+  # duplicate of pylint W0612 (unused-variable)
+  F841,
 
 # Accessibility/large fonts and PEP8 unfriendly:
 max-line-length = 100


### PR DESCRIPTION
This should help avoid

```
ValueError: Error code '#' supplied to 'extend-ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'
```