### PR TITLE
Pin to earlier setuptools for 3.8/2.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
           - flake8-docstrings # uses pydocstyle
 
   - repo: https://github.com/pycqa/pylint.git
-    rev: v2.17.2
+    rev: v3.0.0a6
     hooks:
       - id: pylint
         args:

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ description = run the tests with pytest
 setenv =
     ANSIBLE_FORCE_COLOR = 1
     URL_BASE = https://github.com/ansible/ansible/archive/
+
 passenv =
     GITHUB_TOKEN
 deps =
@@ -38,16 +39,17 @@ commands_pre =
     bash -c 'cd {envdir}/collections/ansible/scm && ansible-galaxy collection build'
     bash -c 'cd {envdir}/collections/ansible/scm && ansible-galaxy collection install *.tar.gz --force'
     rm -rf {envdir}/collections/ansible/scm
-    python --version
-    pip freeze
+    # Avoid "Setuptools is replacing distutils"
+    sanity-py3.8-2.9: pip install setuptools==57.5.0
+    pip freeze --all
 
 commands =
     integration: python -m pytest tests/integration
-    sanity: bash -c 'cd ~/.ansible/collections/ansible_collections/ansible/scm && ansible-test sanity --requirements --python $(echo {envname} | cut -d "-" -f 2 | sed "s/py//")'
+    sanity: bash -c 'cd ~/.ansible/collections/ansible_collections/ansible/scm && ansible-test sanity --local --requirements --python $(echo {envname} | cut -d "-" -f 2 | sed "s/py//")'
     unit: python -m pytest tests/unit
 
 [testenv:lint]
 commands_pre =
     python --version
-    pip freeze
+    pip freeze --all
 commands = pre-commit run --all-files


### PR DESCRIPTION
Fix for 3.8/2.9
```
Running sanity test 'pylint' with Python 3.8
ERROR: Command "/home/bthornto/github/ansible.scm/.tox/sanity-py3.8-2.9/bin/python -m pylint --jobs 0 --reports n --max-line-length 160 --rcfile /home/bthornto/github/ansible.scm/.tox/sanity-py3.8-2.9/lib/python3.8/site-packages/ansible_test/_data/sanity/pylint/config/collection.cfg --output-format json --load-plugins string_format,blacklist,deprecated docs/__init__.py meta/__init__.py plugins/__init__.py plugins/action/__init__.py plugins/action/git_publish.py plugins/action/git_retrieve.py plugins/cache/__init__.py plugins/filter/__init__.py plugins/inventory/__init__.py plugins/lookup/__init__.py plugins/plugin_utils/__init__.py plugins/plugin_utils/command.py plugins/plugin_utils/compatibility.py plugins/plugin_utils/git_base.py plugins/test/__init__.py tests/__init__.py tests/integration/targets/__init__.py tests/integration/test_integration.py" returned exit status 0.
>>> Standard Error
/home/bthornto/github/ansible.scm/.tox/sanity-py3.8-2.9/lib/python3.8/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
>>> Standard Output
```

- pylint back to 3.0.0a6
- add `--all` to `pip freeze`