### PR TITLE
Improve tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ allowlist_externals =
     rm
 
 commands_pre =
+    # Clone the repo before the build to leave behing gitignored files.
     git clone {toxinidir} {[vars]galaxy_build_dir}
     # make sure the toxfile.py is not included in the collection
     rm -rf {[vars]galaxy_build_dir}toxfile.py
@@ -61,13 +62,12 @@ commands_pre =
     pip freeze --all
 
 changedir = 
-    integration: {[vars]collections_root}
     sanity: {[vars]collection_install_dir}
     unit: {[vars]collections_root}
 
 commands =
-    integration: python -m pytest {toxinidir}/tests/integration
-    sanity: bash -c 'ansible-test sanity --local --requirements --python $(echo {envname} | cut -d "-" -f 2 | sed "s/py//")'
+    integration: python -m pytest -p no:ansible-units {toxinidir}/tests/integration
+    sanity: bash -c "ansible-test sanity --local --requirements --python $(echo {envname} | awk -F 'py|-' '{print $3}')"
     unit: python -m pytest -p no:ansible-units {toxinidir}/tests/unit
 
 [testenv:lint]
@@ -76,12 +76,20 @@ commands_pre =
     pip freeze --all
 commands = pre-commit run --all-files
 
-[testenv:unit-py3.8-2.9]
-# ansible 2.9 unit tests require the use of pytest-ansible-units to inject the path
-# and therefore the galaxy.yml file
+
+[testenv:{integration, unit}-py3.8-2.9]
+# ansible 2.9 tests require the use of pytest-ansible-units to inject the path
+# and therefore the galaxy.yml file, the collection install is temporary
+# unit pytes-ansible-units can respect a different ANSIBLE_COLLECTIONS_PATH
 changedir = 
     unit: {[vars]collection_install_dir}
 commands =
+    integration: 
+        bash -c '\
+        cd {[vars]galaxy_build_dir} && \
+        ansible-galaxy collection install *.tar.gz \
+        '
+        python -m pytest {toxinidir}/tests/integration
     unit: 
         cp {toxinidir}/galaxy.yml {[vars]collection_install_dir}
         python -m pytest {toxinidir}/tests/unit

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ url_base = https://github.com/ansible/ansible/archive/
 [testenv]
 description = run the tests with pytest
 
-setenv = 
+setenv =
     ANSIBLE_COLLECTIONS_PATH = {[vars]collections_root}
 
 passenv =
@@ -54,14 +54,14 @@ commands_pre =
     # https://github.com/ansible/ansible/issues/68499
     bash -c '\
         cd {[vars]collection_install_dir} && \
-        git config --global init.defaultBranch main && \ 
+        git config --global init.defaultBranch main && \
         git init .\
         '
     # Avoid "Setuptools is replacing distutils"
     sanity-py3.8-2.9: pip install setuptools==57.5.0
     pip freeze --all
 
-changedir = 
+changedir =
     sanity: {[vars]collection_install_dir}
     unit: {[vars]collections_root}
 
@@ -81,15 +81,15 @@ commands = pre-commit run --all-files
 # ansible 2.9 tests require the use of pytest-ansible-units to inject the path
 # and therefore the galaxy.yml file, the collection install is temporary
 # unit pytes-ansible-units can respect a different ANSIBLE_COLLECTIONS_PATH
-changedir = 
+changedir =
     unit: {[vars]collection_install_dir}
 commands =
-    integration: 
+    integration:
         bash -c '\
         cd {[vars]galaxy_build_dir} && \
         ansible-galaxy collection install *.tar.gz \
         '
         python -m pytest {toxinidir}/tests/integration
-    unit: 
+    unit:
         cp {toxinidir}/galaxy.yml {[vars]collection_install_dir}
         python -m pytest {toxinidir}/tests/unit

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,19 @@ env_list =
 minversion = 4.4.8
 package = external
 
+[vars]
+name=ansible
+namespace=scm
+galaxy_build_dir = {envtmpdir}/{[vars]name}/{[vars]namespace}/
+collections_root = {envtmpdir}/collections/
+collection_install_dir = {[vars]collections_root}/ansible_collections/{[vars]name}/{[vars]namespace}/
+url_base = https://github.com/ansible/ansible/archive/
+
 [testenv]
 description = run the tests with pytest
-setenv =
-    ANSIBLE_FORCE_COLOR = 1
-    URL_BASE = https://github.com/ansible/ansible/archive/
+
+setenv = 
+    ANSIBLE_COLLECTIONS_PATH = {[vars]collections_root}
 
 passenv =
     GITHUB_TOKEN
@@ -19,37 +27,61 @@ deps =
     integration,unit: -r requirements.txt
     integration,unit: -r test-requirements.txt
     lint: pre-commit
-    2.9: {env:URL_BASE}stable-2.9.tar.gz
-    2.12: {env:URL_BASE}stable-2.12.tar.gz
-    2.13: {env:URL_BASE}stable-2.13.tar.gz
-    2.14: {env:URL_BASE}stable-2.14.tar.gz
-    milestone: {env:URL_BASE}milestone.tar.gz
-    devel: {env:URL_BASE}/devel.tar.gz
+    2.9: {[vars]url_base}stable-2.9.tar.gz
+    2.12: {[vars]url_base}stable-2.12.tar.gz
+    2.13: {[vars]url_base}stable-2.13.tar.gz
+    2.14: {[vars]url_base}stable-2.14.tar.gz
+    milestone: {[vars]url_base}milestone.tar.gz
+    devel: {[vars]url_base}devel.tar.gz
 
 skip_install = true
 allowlist_externals =
-    rm
     bash
+    cp
     git
+    rm
 
 commands_pre =
-    git clone {toxinidir} {envdir}/collections/ansible/scm
+    git clone {toxinidir} {[vars]galaxy_build_dir}
     # make sure the toxfile.py is not included in the collection
-    rm -rf {envdir}/collections/ansible/scm/toxfile.py
-    bash -c 'cd {envdir}/collections/ansible/scm && ansible-galaxy collection build'
-    bash -c 'cd {envdir}/collections/ansible/scm && ansible-galaxy collection install *.tar.gz --force'
-    rm -rf {envdir}/collections/ansible/scm
+    rm -rf {[vars]galaxy_build_dir}toxfile.py
+    bash -c '\
+        cd {[vars]galaxy_build_dir} && \
+        ansible-galaxy collection build && \
+        ansible-galaxy collection install *.tar.gz --force -p {[vars]collections_root} \
+        '
+    # https://github.com/ansible/ansible/issues/68499
+    bash -c '\
+        cd {[vars]collection_install_dir} && \
+        git config --global init.defaultBranch main && \ 
+        git init .\
+        '
     # Avoid "Setuptools is replacing distutils"
     sanity-py3.8-2.9: pip install setuptools==57.5.0
     pip freeze --all
 
+changedir = 
+    integration: {[vars]collections_root}
+    sanity: {[vars]collection_install_dir}
+    unit: {[vars]collections_root}
+
 commands =
-    integration: python -m pytest tests/integration
-    sanity: bash -c 'cd ~/.ansible/collections/ansible_collections/ansible/scm && ansible-test sanity --local --requirements --python $(echo {envname} | cut -d "-" -f 2 | sed "s/py//")'
-    unit: python -m pytest tests/unit
+    integration: python -m pytest {toxinidir}/tests/integration
+    sanity: bash -c 'ansible-test sanity --local --requirements --python $(echo {envname} | cut -d "-" -f 2 | sed "s/py//")'
+    unit: python -m pytest -p no:ansible-units {toxinidir}/tests/unit
 
 [testenv:lint]
 commands_pre =
     python --version
     pip freeze --all
 commands = pre-commit run --all-files
+
+[testenv:unit-py3.8-2.9]
+# ansible 2.9 unit tests require the use of pytest-ansible-units to inject the path
+# and therefore the galaxy.yml file
+changedir = 
+    unit: {[vars]collection_install_dir}
+commands =
+    unit: 
+        cp {toxinidir}/galaxy.yml {[vars]collection_install_dir}
+        python -m pytest {toxinidir}/tests/unit


### PR DESCRIPTION
Some tox.ini cleanup
- move the collection work into the tox temp directory
- this allows for parellel runs with conflict
- the tmp directory is auto cleaned up
- limit the use of ansible units to just 2.9 where needed
