### PR TITLE
Update test requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,10 @@
 black
-coverage==4.5.4
-flake8
 git+https://github.com/ansible-community/pytest-ansible-units.git
 git+https://github.com/ansible-network/pytest-ansible-network-integration.git
 git+https://github.com/cidrblock/ansitest.git
 mypy
 pre-commit
+pylint
 pytest-xdist
+ruff
 tox


### PR DESCRIPTION
Remove the dep on coverage, test coverage reporting will be done in the future
Remove flake8 as it is no longer in use
Add pylint and ruff as a dev convenience


The removal of coverage should also fix the issues in other open PRs