### PR TITLE
Use tox-ansible as installer, remove unit flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,6 @@
     "python.linting.mypyEnabled": true,
     "prettier.enable": true,
     "python.testing.pytestArgs": [
-        "--ansible-unit",
         "tests"
     ],
     "python.testing.unittestEnabled": false,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,7 @@
 black
-git+https://github.com/ansible-community/pytest-ansible.git
 git+https://github.com/ansible-network/pytest-ansible-network-integration.git
 git+https://github.com/tox-dev/tox-ansible.git@uplift_v2
 mypy
 pre-commit
 pylint
-pytest-xdist
 ruff
-tox


### PR DESCRIPTION
tox-ansible will install the deps as needed, the unit flag is no longer required.