### PR TITLE
 Implement Support for github  tags

### DIFF
--- a/changelogs/fragments/support_git_tag.yaml
+++ b/changelogs/fragments/support_git_tag.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - add support for git tags.

--- a/docs/ansible.scm.git_publish_module.rst
+++ b/docs/ansible.scm.git_publish_module.rst
@@ -141,6 +141,54 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>tag</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The token used to identify a specific release</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>annotation</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Specify annotate</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>message</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Specify tag message</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>timeout</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/ansible.scm.git_retrieve_module.rst
+++ b/docs/ansible.scm.git_retrieve_module.rst
@@ -135,6 +135,22 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>tag</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Specify the tag</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>token</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/action/git_publish.py
+++ b/plugins/action/git_publish.py
@@ -275,7 +275,7 @@ class ActionModule(GitBase):
             self._add,
             self._commit,
         )
-        if self._task.args["tag"]:
+        if self._task.args.get("tag"):
             steps += (self._tag,)
 
         steps += (self._push,

--- a/plugins/action/git_publish.py
+++ b/plugins/action/git_publish.py
@@ -177,7 +177,7 @@ class ActionModule(GitBase):
         self._run_command(command=command)
 
     def _tag(self):
-        """Create a tag object"""
+        """Create a tag object."""
         command_parts = list(self._base_command)
         message = self._task.args["tag"].get("message")
         annotate = self._task.args["tag"]["annotation"]

--- a/plugins/action/git_retrieve.py
+++ b/plugins/action/git_retrieve.py
@@ -183,7 +183,7 @@ class ActionModule(GitBase):
             import q
             q(tag)
             command_parts.extend(
-            ["clone", "--depth=1", "--progress", "--no-single-branch", origin, tag],
+            ["clone", "--depth=1", "--progress", "--branch", tag, origin],
             )
         else:
             command_parts.extend(
@@ -270,7 +270,11 @@ class ActionModule(GitBase):
         if self._branch_exists:
             command_parts.extend(["switch", branch])
         else:
-            command_parts.extend(["checkout", "-t", "-b", branch])
+            tag = self._task.args["origin"].get("tag")
+            if tag:
+                command_parts.extend(["checkout", "-b", branch])
+            else:
+                command_parts.extend(["checkout", "-t", "-b", branch])
 
         command = Command(
             command_parts=command_parts,

--- a/plugins/action/git_retrieve.py
+++ b/plugins/action/git_retrieve.py
@@ -181,11 +181,11 @@ class ActionModule(GitBase):
         tag = self._task.args["origin"].get("tag")
         if tag:
             command_parts.extend(
-            ["clone", "--depth=1", "--progress", "--branch", tag, origin],
+                ["clone", "--depth=1", "--progress", "--branch", tag, origin],
             )
         else:
             command_parts.extend(
-            ["clone", "--depth=1", "--progress", "--no-single-branch", origin],
+                ["clone", "--depth=1", "--progress", "--no-single-branch", origin],
             )
 
         command = Command(

--- a/plugins/action/git_retrieve.py
+++ b/plugins/action/git_retrieve.py
@@ -180,8 +180,6 @@ class ActionModule(GitBase):
 
         tag = self._task.args["origin"].get("tag")
         if tag:
-            import q
-            q(tag)
             command_parts.extend(
             ["clone", "--depth=1", "--progress", "--branch", tag, origin],
             )

--- a/plugins/action/git_retrieve.py
+++ b/plugins/action/git_retrieve.py
@@ -178,9 +178,17 @@ class ActionModule(GitBase):
             command_parts.extend(cli_parameters)
             no_log[token_base64] = "<TOKEN>"
 
-        command_parts.extend(
+        tag = self._task.args["origin"].get("tag")
+        if tag:
+            import q
+            q(tag)
+            command_parts.extend(
+            ["clone", "--depth=1", "--progress", "--no-single-branch", origin, tag],
+            )
+        else:
+            command_parts.extend(
             ["clone", "--depth=1", "--progress", "--no-single-branch", origin],
-        )
+            )
 
         command = Command(
             command_parts=command_parts,

--- a/plugins/modules/git_publish.py
+++ b/plugins/modules/git_publish.py
@@ -61,6 +61,17 @@ options:
         interacting with the origin repository
       - Will only be used for https based connections
     type: str
+  tag:
+    description:
+      - The token used to identify a specific release
+    type: dict
+    suboptions:
+      annotation:
+        description: Specify annotate
+        type: str
+      message:
+        description: Specify tag message
+        type: str
   user:
     description:
       - Details for the user to be used for the commit

--- a/plugins/modules/git_retrieve.py
+++ b/plugins/modules/git_retrieve.py
@@ -68,7 +68,9 @@ options:
         description:
           - The URL for the origin repository
         type: str
-
+      tag:
+        description: Specify the tag
+        type: str
   parent_directory:
     description:
       - The local directory where the repository will be placed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
-  enables user to use `git_publish` to push a tag 
- enables user to use `git_retrieve` pull repository  with specific tag.

resolves: https://github.com/ansible-collections/ansible.scm/issues/176


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
 
- Feature Pull Request
 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
git_publish
git_retrieve
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

##### Example
```paste below
 
    
- name: Publish the changes
      ansible.scm.git_publish:
        tag:
          annotation: "{{ time }}"
          message: "backup_config"
        path: "{{ repository['path'] }}"
        
 
    - name: Retrieve a repository from a distant location and make it available locally
      ansible.scm.git_retrieve:
        origin:
          url: git@github.com:rohitthakur2590/network_automation_backups.git
          tag: "2023-05-30-19-01"
        parent_directory: "/home/rothakur/ansible-collections/collections/ansible_collections/ansible/scm/"
      register: repository
    

```
