### PR TITLE
Fix pytest error

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -51,7 +51,7 @@ def run(localhost_project: AnsibleProject, environment: Dict[str, str]) -> None:
         print(process.stdout.decode("utf-8"))
         print(process.stderr.decode("utf-8"))
 
-        pytest.fail(reason=f"Integration test failed: {localhost_project.role}")
+        pytest.fail(f"Integration test failed: {localhost_project.role}")
 
 
 def test_integration(

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -51,7 +51,7 @@ def run(localhost_project: AnsibleProject, environment: Dict[str, str]) -> None:
         print(process.stdout.decode("utf-8"))
         print(process.stderr.decode("utf-8"))
 
-        pytest.fail(msg=f"Integration test failed: {localhost_project.role}")
+        pytest.fail(reason=f"Integration test failed: {localhost_project.role}")
 
 
 def test_integration(


### PR DESCRIPTION
```
PytestRemovedIn8Warning: pytest.fail(msg=...) is now deprecated, use pytest.fail(reason=...) instead
    pytest.fail(msg=f"Integration test failed: {localhost_project.role}")
```