### PR TITLE
Make 'allow-empty' optional

### DIFF
--- a/docs/ansible.scm.git_publish_module.rst
+++ b/docs/ansible.scm.git_publish_module.rst
@@ -36,6 +36,25 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>allow_empty</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allow an empty commit even if no changes have been made.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>commit</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/action/git_publish.py
+++ b/plugins/action/git_publish.py
@@ -180,7 +180,8 @@ class ActionModule(GitBase):
         )
 
         self._run_command(
-            command=command, **({} if self._task.args["allow_empty"] else {"ignore_errors": True}),
+            command=command,
+            **({} if self._task.args["allow_empty"] else {"ignore_errors": True}),
         )
 
     def _tag(self: T) -> None:

--- a/plugins/action/git_publish.py
+++ b/plugins/action/git_publish.py
@@ -169,13 +169,17 @@ class ActionModule(GitBase):
         """Perform a commit for the pending push."""
         command_parts = list(self._base_command)
         message = self._task.args["commit"]["message"].format(play_name=self._play_name)
-        message = message.replace("'", '"')
-        command_parts.extend(["commit", "--allow-empty", "-m", message])
+        message = message.replace("'", '"')       
+        command_parts.extend(["commit", "-m", message])
+        if self._task.args["allow_empty"]:
+            command_parts.extend(["--allow-empty"])
+
         command = Command(
             command_parts=command_parts,
             fail_msg=f"Failed to perform the commit: {message}",
         )
-        self._run_command(command=command)
+
+        self._run_command(command=command, **( {} if self._task.args["allow_empty"] else {"ignore_errors":True} ) )
 
     def _tag(self: T) -> None:
         """Create a tag object."""
@@ -289,5 +293,13 @@ class ActionModule(GitBase):
         if self._result.pr_url and self._task.args["open_browser"]:
             webbrowser.open(self._result.pr_url, new=2)
 
-        self._result.msg = f"Successfully published local changes from: {self._path_to_repo}"
+        for cmd_output in self._result.output:
+            if "nothing to commit, working tree clean" in cmd_output['stdout_lines']:
+                self._result.changed = False
+
+        if self._result.changed:
+            self._result.msg = f"Successfully published local changes from: {self._path_to_repo}"
+        else:
+            self._result.msg = f"nothing to commit, working tree clean"
+
         return asdict(self._result)

--- a/plugins/action/git_publish.py
+++ b/plugins/action/git_publish.py
@@ -169,7 +169,7 @@ class ActionModule(GitBase):
         """Perform a commit for the pending push."""
         command_parts = list(self._base_command)
         message = self._task.args["commit"]["message"].format(play_name=self._play_name)
-        message = message.replace("'", '"')       
+        message = message.replace("'", '"')
         command_parts.extend(["commit", "-m", message])
         if self._task.args["allow_empty"]:
             command_parts.extend(["--allow-empty"])
@@ -179,7 +179,9 @@ class ActionModule(GitBase):
             fail_msg=f"Failed to perform the commit: {message}",
         )
 
-        self._run_command(command=command, **( {} if self._task.args["allow_empty"] else {"ignore_errors":True} ) )
+        self._run_command(
+            command=command, **({} if self._task.args["allow_empty"] else {"ignore_errors": True}),
+        )
 
     def _tag(self: T) -> None:
         """Create a tag object."""
@@ -294,12 +296,12 @@ class ActionModule(GitBase):
             webbrowser.open(self._result.pr_url, new=2)
 
         for cmd_output in self._result.output:
-            if "nothing to commit, working tree clean" in cmd_output['stdout_lines']:
+            if "nothing to commit, working tree clean" in cmd_output["stdout_lines"]:
                 self._result.changed = False
 
         if self._result.changed:
             self._result.msg = f"Successfully published local changes from: {self._path_to_repo}"
         else:
-            self._result.msg = f"nothing to commit, working tree clean"
+            self._result.msg = "nothing to commit, working tree clean"
 
         return asdict(self._result)

--- a/plugins/modules/git_publish.py
+++ b/plugins/modules/git_publish.py
@@ -35,7 +35,7 @@ options:
     elements: str
     type: list
   allow_empty:
-    description: 
+    description:
       - Allow an empty commit even if no changes have been made.
     default: true
     type: bool

--- a/plugins/modules/git_publish.py
+++ b/plugins/modules/git_publish.py
@@ -34,6 +34,11 @@ options:
     default: ['--all']
     elements: str
     type: list
+  allow_empty:
+    description: 
+      - Allow an empty commit even if no changes have been made.
+    default: true
+    type: bool
   open_browser:
     description:
       - Open the default browser to the pull-request page


### PR DESCRIPTION
##### SUMMARY
Make 'allow-empty' flag optional. This allows for not making a commit if no changes were made.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
git_publish

##### ADDITIONAL INFORMATION
Currently, the module behaviour means that even if no changes had been made to the repository a commit is still made. Making this flag optional allows the user to modify the behaviour of the module to allow for not making an empty commit.

My personal use case:
I have a playbook that pulls a repo, checks a file, makes a change if needed, and commits that change to Github. Github is then configured to run an action that deploys that change. Looking to make this process more effecient by not running GH actions where not needed.
