### PR TITLE
add missing origin to command invocation when tag is used

### DIFF
--- a/plugins/action/git_retrieve.py
+++ b/plugins/action/git_retrieve.py
@@ -185,7 +185,7 @@ class ActionModule(GitBase):
         )
         if tag:
             command_parts.extend(
-                ["--branch", tag],
+                ["--branch", tag, origin],
             )
         else:
             command_parts.extend(


### PR DESCRIPTION
##### SUMMARY
Retrieving a git repository with tag specified in origin parameter doesn't work.

This happens because the actual origin URL is not appended to the command argument list if a tag has been specified.

Fixes #265 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.scm.git_retrieve

##### ADDITIONAL INFORMATION
None
