### PR TITLE
add Gist support to ansible.scm

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Name | Description
 --- | ---
 [ansible.scm.git_publish](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.git_publish_module.rst)|Publish changes from a repository available on the execution node to a distant location
 [ansible.scm.git_retrieve](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.git_retrieve_module.rst)|Retrieve a repository from a distant location and make it available on the execution node
+[ansible.scm.gist_publish](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.gist_publish_module.rst)|Publish content to a GitHub gist or GitLab snippet
+[ansible.scm.gist_retrieve](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.gist_retrieve_module.rst)|Retrieve a GitHub gist or GitLab snippet
 
 <!--end collection content-->
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Some modules and plugins require external libraries. Please check the requiremen
 ### Modules
 Name | Description
 --- | ---
-[ansible.scm.git_publish](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.git_publish_module.rst)|Publish changes from a repository available on the execution node to a distant location
-[ansible.scm.git_retrieve](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.git_retrieve_module.rst)|Retrieve a repository from a distant location and make it available on the execution node
 [ansible.scm.gist_publish](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.gist_publish_module.rst)|Publish content to a GitHub gist or GitLab snippet
 [ansible.scm.gist_retrieve](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.gist_retrieve_module.rst)|Retrieve a GitHub gist or GitLab snippet
+[ansible.scm.git_publish](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.git_publish_module.rst)|Publish changes from a repository available on the execution node to a distant location
+[ansible.scm.git_retrieve](https://github.com/ansible-collections/ansible.scm/blob/main/docs/ansible.scm.git_retrieve_module.rst)|Retrieve a repository from a distant location and make it available on the execution node
 
 <!--end collection content-->
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -250,3 +250,9 @@ releases:
     fragments:
       - bump_2.16.yaml
     release_date: "2026-03-26"
+  3.3.0:
+    changes:
+      minor_changes:
+        - Add ansible.scm.gist_publish module and action plugin for GitHub gists and GitLab snippets
+        - Add ansible.scm.gist_retrieve module and action plugin for GitHub gists and GitLab snippets
+    release_date: "2026-05-15"

--- a/plugins/action/gist_publish.py
+++ b/plugins/action/gist_publish.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""The gist_publish action plugin."""
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+from dataclasses import asdict
+from typing import Dict, Optional, TypeVar, Union
+
+from ansible.errors import AnsibleActionFail
+from ansible.parsing.dataloader import DataLoader
+from ansible.playbook.play_context import PlayContext
+from ansible.playbook.task import Task
+from ansible.plugins import loader as plugin_loader
+from ansible.plugins.connection.local import Connection
+from ansible.template import Templar
+
+from ..modules.gist_publish import DOCUMENTATION
+from ..plugin_utils.gist_base import ActionInit, GistBase, GistResultBase
+from ..plugin_utils.github_gist import GitHubGist
+from ..plugin_utils.gitlab_snippet import GitLabSnippet
+
+
+JSONTypes = Union[bool, int, str, Dict, list]  # type: ignore
+
+T = TypeVar("T", bound="ActionModule")  # pylint: disable=invalid-name, useless-suppression
+
+
+class ActionModule(GistBase):
+    """Publish content to a gist or snippet."""
+
+    def __init__(  # noqa: PLR0913
+        self: T,
+        connection: Connection,
+        loader: DataLoader,
+        play_context: PlayContext,
+        shared_loader_obj: plugin_loader,
+        task: Task,
+        templar: Templar,
+    ) -> None:
+        """Initialize the action plugin."""
+        super().__init__(
+            ActionInit(
+                connection=connection,
+                loader=loader,
+                play_context=play_context,
+                shared_loader_obj=shared_loader_obj,
+                templar=templar,
+                task=task,
+            ),
+        )
+        self._result: GistResultBase = GistResultBase()
+        self._supports_async = True
+
+    def _apply_result(self: T, normalized: Dict[str, JSONTypes]) -> None:
+        """Populate the task result from a normalized API response."""
+        self._result.id = str(normalized.get("id", ""))
+        self._result.html_url = str(normalized.get("html_url", ""))
+        self._result.description = str(normalized.get("description", ""))
+        files = normalized.get("files", {})
+        self._result.files = files if isinstance(files, dict) else {}
+
+    def _publish_github(self: T) -> None:
+        """Create or update a GitHub gist."""
+        client = self._github_client()
+        files = self._normalize_files(self._task.args["files"])
+        gist_id = self._task.args.get("gist_id")
+        description = self._task.args.get("description", "")
+        public = self._task.args.get("public", False)
+
+        if gist_id:
+            existing, error = client.get(gist_id)
+            if existing is None:
+                self._result.failed = True
+                self._result.msg = f"Failed to retrieve gist {gist_id}: {error}"
+                return
+            if GitHubGist.files_match(GitHubGist.extract_files(existing), files):
+                self._apply_result(GitHubGist.normalize_result(existing))
+                self._result.changed = False
+                self._result.msg = f"Gist {gist_id} already up to date"
+                return
+            updated, error = client.update(gist_id, description, public, files)
+            if updated is None:
+                self._result.failed = True
+                self._result.msg = f"Failed to update gist {gist_id}: {error}"
+                return
+            self._apply_result(GitHubGist.normalize_result(updated))
+            self._result.changed = True
+            self._result.msg = f"Successfully updated gist {self._result.id}"
+            return
+
+        created, error = client.create(description, public, files)
+        if created is None:
+            self._result.failed = True
+            self._result.msg = f"Failed to create gist: {error}"
+            return
+        self._apply_result(GitHubGist.normalize_result(created))
+        self._result.changed = True
+        self._result.msg = f"Successfully created gist {self._result.id}"
+
+    def _publish_gitlab(self: T) -> None:
+        """Create or update a GitLab snippet."""
+        client = self._gitlab_client()
+        files = self._normalize_files(self._task.args["files"])
+        gist_id = self._task.args.get("gist_id")
+        project_id = self._task.args.get("project_id")
+        description = self._task.args.get("description", "")
+        title = self._task.args.get("title") or description or "ansible snippet"
+        visibility = self._task.args.get("visibility", "private")
+
+        if gist_id:
+            existing, error = client.get(gist_id, project_id=project_id)
+            if existing is None:
+                self._result.failed = True
+                self._result.msg = f"Failed to retrieve snippet {gist_id}: {error}"
+                return
+            if GitLabSnippet.files_match(GitLabSnippet.extract_files(existing), files):
+                self._apply_result(GitLabSnippet.normalize_result(existing))
+                self._result.changed = False
+                self._result.msg = f"Snippet {gist_id} already up to date"
+                return
+            updated, error = client.update(
+                gist_id,
+                title,
+                description,
+                visibility,
+                files,
+                project_id=project_id,
+            )
+            if updated is None:
+                self._result.failed = True
+                self._result.msg = f"Failed to update snippet {gist_id}: {error}"
+                return
+            self._apply_result(GitLabSnippet.normalize_result(updated))
+            self._result.changed = True
+            self._result.msg = f"Successfully updated snippet {self._result.id}"
+            return
+
+        created, error = client.create(
+            title,
+            description,
+            visibility,
+            files,
+            project_id=project_id,
+        )
+        if created is None:
+            self._result.failed = True
+            self._result.msg = f"Failed to create snippet: {error}"
+            return
+        self._apply_result(GitLabSnippet.normalize_result(created))
+        self._result.changed = True
+        self._result.msg = f"Successfully created snippet {self._result.id}"
+
+    def _delete(self: T) -> None:
+        """Delete a gist or snippet."""
+        gist_id = self._task.args.get("gist_id")
+        if not gist_id:
+            raise AnsibleActionFail("gist_id is required when state is absent")
+
+        provider = self._task.args.get("provider", "github")
+        if provider == "github":
+            deleted, error = self._github_client().delete(gist_id)
+        else:
+            deleted, error = self._gitlab_client().delete(
+                gist_id,
+                project_id=self._task.args.get("project_id"),
+            )
+
+        if not deleted:
+            self._result.failed = True
+            self._result.msg = f"Failed to delete {provider} resource {gist_id}: {error}"
+            return
+
+        self._result.id = gist_id
+        self._result.changed = True
+        self._result.msg = f"Successfully deleted {provider} resource {gist_id}"
+
+    def run(
+        self: T,
+        tmp: None = None,
+        task_vars: Optional[Dict[str, JSONTypes]] = None,
+    ) -> Dict[str, JSONTypes]:
+        """Run the action plugin."""
+        self._task.diff = False
+        super().run(task_vars=task_vars)
+
+        try:
+            self._check_argspec(DOCUMENTATION)
+            self._timeout = self._task.args.get("timeout", 30)
+            state = self._task.args.get("state", "present")
+
+            if state == "absent":
+                self._delete()
+            elif not self._task.args.get("files"):
+                raise AnsibleActionFail("files must contain at least one file when state is present")
+            else:
+                provider = self._task.args.get("provider", "github")
+                if provider == "github":
+                    self._publish_github()
+                else:
+                    self._publish_gitlab()
+        except AnsibleActionFail:
+            raise
+
+        return asdict(self._result)

--- a/plugins/action/gist_publish.py
+++ b/plugins/action/gist_publish.py
@@ -198,7 +198,9 @@ class ActionModule(GistBase):
             if state == "absent":
                 self._delete()
             elif not self._task.args.get("files"):
-                raise AnsibleActionFail("files must contain at least one file when state is present")
+                raise AnsibleActionFail(
+                    "files must contain at least one file when state is present",
+                )
             else:
                 provider = self._task.args.get("provider", "github")
                 if provider == "github":

--- a/plugins/action/gist_retrieve.py
+++ b/plugins/action/gist_retrieve.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""The gist_retrieve action plugin."""
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+from dataclasses import asdict
+from typing import Dict, Optional, TypeVar, Union
+
+from ansible.errors import AnsibleActionFail
+from ansible.parsing.dataloader import DataLoader
+from ansible.playbook.play_context import PlayContext
+from ansible.playbook.task import Task
+from ansible.plugins import loader as plugin_loader
+from ansible.plugins.connection.local import Connection
+from ansible.template import Templar
+
+from ..modules.gist_retrieve import DOCUMENTATION
+from ..plugin_utils.gist_base import ActionInit, GistBase, GistResultBase
+from ..plugin_utils.github_gist import GitHubGist
+from ..plugin_utils.gitlab_snippet import GitLabSnippet
+
+
+JSONTypes = Union[bool, int, str, Dict, list]  # type: ignore
+
+T = TypeVar("T", bound="ActionModule")  # pylint: disable=invalid-name, useless-suppression
+
+
+class ActionModule(GistBase):
+    """Retrieve a gist or snippet."""
+
+    def __init__(  # noqa: PLR0913
+        self: T,
+        connection: Connection,
+        loader: DataLoader,
+        play_context: PlayContext,
+        shared_loader_obj: plugin_loader,
+        task: Task,
+        templar: Templar,
+    ) -> None:
+        """Initialize the action plugin."""
+        super().__init__(
+            ActionInit(
+                connection=connection,
+                loader=loader,
+                play_context=play_context,
+                shared_loader_obj=shared_loader_obj,
+                templar=templar,
+                task=task,
+            ),
+        )
+        self._result: GistResultBase = GistResultBase()
+        self._supports_async = True
+
+    def _apply_result(self: T, normalized: Dict[str, JSONTypes]) -> None:
+        """Populate the task result from a normalized API response."""
+        self._result.id = str(normalized.get("id", ""))
+        self._result.html_url = str(normalized.get("html_url", ""))
+        self._result.description = str(normalized.get("description", ""))
+        files = normalized.get("files", {})
+        self._result.files = files if isinstance(files, dict) else {}
+
+    def run(
+        self: T,
+        tmp: None = None,
+        task_vars: Optional[Dict[str, JSONTypes]] = None,
+    ) -> Dict[str, JSONTypes]:
+        """Run the action plugin."""
+        self._task.diff = False
+        super().run(task_vars=task_vars)
+
+        self._check_argspec(DOCUMENTATION)
+        self._timeout = self._task.args.get("timeout", 30)
+        gist_id = self._task.args.get("gist_id")
+        if not gist_id:
+            raise AnsibleActionFail("gist_id is required")
+        provider = self._task.args.get("provider", "github")
+
+        if provider == "github":
+            gist, error = self._github_client().get(gist_id)
+            if gist is None:
+                raise AnsibleActionFail(f"Failed to retrieve gist {gist_id}: {error}")
+            self._apply_result(GitHubGist.normalize_result(gist))
+        else:
+            snippet, error = self._gitlab_client().get(
+                gist_id,
+                project_id=self._task.args.get("project_id"),
+            )
+            if snippet is None:
+                raise AnsibleActionFail(f"Failed to retrieve snippet {gist_id}: {error}")
+            self._apply_result(GitLabSnippet.normalize_result(snippet))
+
+        self._result.changed = False
+        self._result.msg = f"Successfully retrieved {provider} resource {gist_id}"
+        return asdict(self._result)

--- a/plugins/modules/gist_publish.py
+++ b/plugins/modules/gist_publish.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+DOCUMENTATION = """
+module: gist_publish
+short_description: Publish content to a GitHub gist or GitLab snippet
+version_added: "3.3.0"
+description:
+    - Create or update a GitHub gist or GitLab snippet from task content
+    - Delete a gist or snippet when O(state=absent)
+options:
+  provider:
+    description:
+      - The hosting provider for the gist or snippet
+    choices:
+      - github
+      - gitlab
+    default: github
+    type: str
+  token:
+    description:
+      - API token used to authenticate to the provider
+      - If omitted, the module uses C(GITHUB_TOKEN) or C(GITLAB_TOKEN) from the environment
+    type: str
+  api_url:
+    description:
+      - Base API URL for the provider
+      - Defaults to C(https://api.github.com) for GitHub
+      - Defaults to C(https://gitlab.com/api/v4) for GitLab
+    type: str
+  gist_id:
+    description:
+      - Existing gist or snippet id to update or delete
+      - Required when O(state=absent)
+    type: str
+  description:
+    description:
+      - Description for the gist or snippet
+    default: ""
+    type: str
+  title:
+    description:
+      - Title for GitLab snippets
+      - Ignored for GitHub gists
+    default: ""
+    type: str
+  public:
+    description:
+      - Whether the GitHub gist is public
+      - Ignored for GitLab snippets
+    default: false
+    type: bool
+  visibility:
+    description:
+      - Visibility for GitLab snippets
+      - Ignored for GitHub gists
+    choices:
+      - private
+      - internal
+      - public
+    default: private
+    type: str
+  project_id:
+    description:
+      - GitLab project id or URL-encoded path for project snippets
+      - If omitted, a personal GitLab snippet is used
+    type: str
+  files:
+    description:
+      - Files to publish, keyed by filename
+      - Required when O(state=present)
+    type: dict
+    default: {}
+  state:
+    description:
+      - Whether the gist or snippet should be present or absent
+    choices:
+      - present
+      - absent
+    default: present
+    type: str
+  timeout:
+    description:
+      - Timeout in seconds for each API request
+    default: 30
+    type: int
+  validate_certs:
+    description:
+      - Whether TLS certificates should be validated
+    default: true
+    type: bool
+notes:
+    - This plugin always runs on the execution node
+    - This plugin will not run on a managed node
+author:
+    - Ansible Network Community (ansible-network)
+"""
+
+EXAMPLES = r"""
+- name: Publish a report to a private GitHub gist
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create gist
+      ansible.scm.gist_publish:
+        provider: github
+        description: Meraki report
+        public: false
+        files:
+          report.json:
+            content: "{{ report | to_nice_json }}"
+      register: gist
+
+    - name: Show gist URL
+      ansible.builtin.debug:
+        msg: "{{ gist.html_url }}"
+"""
+
+RETURN = r"""
+id:
+  description: Gist or snippet id
+  returned: on success
+  type: str
+html_url:
+  description: Web URL for the gist or snippet
+  returned: on success
+  type: str
+description:
+  description: Gist or snippet description
+  returned: on success
+  type: str
+files:
+  description: Published file contents keyed by filename
+  returned: on success
+  type: dict
+changed:
+  description: Whether the remote gist or snippet changed
+  returned: always
+  type: bool
+"""

--- a/plugins/modules/gist_retrieve.py
+++ b/plugins/modules/gist_retrieve.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Red Hat
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+DOCUMENTATION = """
+module: gist_retrieve
+short_description: Retrieve a GitHub gist or GitLab snippet
+version_added: "3.3.0"
+description:
+    - Retrieve file content from a GitHub gist or GitLab snippet
+options:
+  provider:
+    description:
+      - The hosting provider for the gist or snippet
+    choices:
+      - github
+      - gitlab
+    default: github
+    type: str
+  token:
+    description:
+      - API token used to authenticate to the provider
+      - If omitted, the module uses C(GITHUB_TOKEN) or C(GITLAB_TOKEN) from the environment
+    type: str
+  api_url:
+    description:
+      - Base API URL for the provider
+      - Defaults to C(https://api.github.com) for GitHub
+      - Defaults to C(https://gitlab.com/api/v4) for GitLab
+    type: str
+  gist_id:
+    description:
+      - Gist or snippet id to retrieve
+    required: true
+    type: str
+  project_id:
+    description:
+      - GitLab project id or URL-encoded path for project snippets
+    type: str
+  timeout:
+    description:
+      - Timeout in seconds for each API request
+    default: 30
+    type: int
+  validate_certs:
+    description:
+      - Whether TLS certificates should be validated
+    default: true
+    type: bool
+notes:
+    - This plugin always runs on the execution node
+    - This plugin will not run on a managed node
+author:
+    - Ansible Network Community (ansible-network)
+"""
+
+EXAMPLES = r"""
+- name: Retrieve a gist
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Get gist content
+      ansible.scm.gist_retrieve:
+        provider: github
+        gist_id: abc123def456
+      register: gist
+
+    - name: Show files
+      ansible.builtin.debug:
+        var: gist.files
+"""
+
+RETURN = r"""
+id:
+  description: Gist or snippet id
+  returned: on success
+  type: str
+html_url:
+  description: Web URL for the gist or snippet
+  returned: on success
+  type: str
+description:
+  description: Gist or snippet description
+  returned: on success
+  type: str
+files:
+  description: Retrieved file contents keyed by filename
+  returned: on success
+  type: dict
+changed:
+  description: Always false for retrieve operations
+  returned: always
+  type: bool
+"""

--- a/plugins/plugin_utils/gist_base.py
+++ b/plugins/plugin_utils/gist_base.py
@@ -99,7 +99,9 @@ class GistBase(ActionBase):  # type: ignore[misc]
             validate_certs=self._task.args.get("validate_certs", True),
         )
 
-    def _normalize_files(self: T, files: Dict[str, JSONTypes], required: bool = True) -> Dict[str, str]:
+    def _normalize_files(
+        self: T, files: Dict[str, JSONTypes], required: bool = True,
+    ) -> Dict[str, str]:
         """Normalize the files dictionary to string contents."""
         normalized: Dict[str, str] = {}
         for name, details in files.items():

--- a/plugins/plugin_utils/gist_base.py
+++ b/plugins/plugin_utils/gist_base.py
@@ -1,0 +1,112 @@
+"""Base classes for gist and snippet action plugins."""
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+import os
+
+from dataclasses import dataclass, field
+from typing import Dict, List, TypeVar, Union
+
+from ansible.errors import AnsibleActionFail
+from ansible.plugins.action import ActionBase
+
+# pylint: disable=import-error
+from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+    AnsibleArgSpecValidator,
+)
+
+from .git_base import ActionInit
+from .github_gist import GitHubGist
+from .gitlab_snippet import GitLabSnippet
+
+
+JSONTypes = Union[bool, int, str, Dict, List]  # type: ignore
+
+T = TypeVar("T", bound="GistBase")  # pylint: disable=invalid-name, useless-suppression
+
+
+@dataclass(frozen=False)
+class GistResultBase:
+    """Data structure for gist task results."""
+
+    changed: bool = False
+    failed: bool = False
+    msg: str = ""
+    id: str = ""  # pylint: disable=invalid-name
+    html_url: str = ""
+    description: str = ""
+    files: Dict[str, str] = field(default_factory=dict)
+
+
+class GistBase(ActionBase):  # type: ignore[misc]
+    """Base class for gist and snippet action plugins."""
+
+    _requires_connection = False
+
+    def __init__(self: T, action_init: ActionInit) -> None:
+        """Initialize the action plugin."""
+        super().__init__(**action_init.asdict)
+        self._result: GistResultBase = GistResultBase()
+        self._timeout: int = 30
+
+    def _check_argspec(self: T, documentation: str) -> None:
+        """Validate task arguments against the module DOCUMENTATION."""
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=documentation,
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+        if self._task.args.get("token") == "":
+            raise AnsibleActionFail("token can not be an empty string")
+
+    def _resolve_token(self: T, provider: str, token: str) -> str:
+        """Resolve API token from task args or environment."""
+        if token:
+            return token
+        env_name = "GITHUB_TOKEN" if provider == "github" else "GITLAB_TOKEN"
+        env_token = os.environ.get(env_name, "")
+        if not env_token:
+            raise AnsibleActionFail(
+                f"token is required when {env_name} is not set in the environment",
+            )
+        return env_token
+
+    def _github_client(self: T) -> GitHubGist:
+        """Create a GitHub gist client from task arguments."""
+        token = self._resolve_token("github", self._task.args.get("token", ""))
+        return GitHubGist(
+            token=token,
+            api_url=self._task.args.get("api_url", "https://api.github.com"),
+            timeout=self._timeout,
+            validate_certs=self._task.args.get("validate_certs", True),
+        )
+
+    def _gitlab_client(self: T) -> GitLabSnippet:
+        """Create a GitLab snippet client from task arguments."""
+        token = self._resolve_token("gitlab", self._task.args.get("token", ""))
+        return GitLabSnippet(
+            token=token,
+            api_url=self._task.args.get("api_url", "https://gitlab.com/api/v4"),
+            timeout=self._timeout,
+            validate_certs=self._task.args.get("validate_certs", True),
+        )
+
+    def _normalize_files(self: T, files: Dict[str, JSONTypes], required: bool = True) -> Dict[str, str]:
+        """Normalize the files dictionary to string contents."""
+        normalized: Dict[str, str] = {}
+        for name, details in files.items():
+            if isinstance(details, dict):
+                normalized[name] = str(details.get("content", ""))
+            else:
+                normalized[name] = str(details)
+        if required and not normalized:
+            raise AnsibleActionFail("files must contain at least one file when state is present")
+        return normalized

--- a/plugins/plugin_utils/github_gist.py
+++ b/plugins/plugin_utils/github_gist.py
@@ -1,0 +1,164 @@
+"""GitHub Gist API client."""
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+import json
+
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+from .http_request import HttpResponse, http_request_safe
+
+
+JSONTypes = Union[bool, int, str, Dict[str, Any], list]  # type: ignore
+
+HttpRequestCallable = Callable[..., Tuple[Optional[HttpResponse], str]]
+
+
+class GitHubGist:
+    """Client for the GitHub Gist REST API."""
+
+    def __init__(
+        self,
+        token: str,
+        api_url: str = "https://api.github.com",
+        timeout: int = 30,
+        validate_certs: bool = True,
+        http_request_func: Optional[HttpRequestCallable] = None,
+    ) -> None:
+        """Initialize the client.
+
+        :param token: GitHub personal access token
+        :param api_url: GitHub API base URL
+        :param timeout: Request timeout in seconds
+        :param validate_certs: Whether to validate TLS certificates
+        :param http_request_func: Optional HTTP request callable for testing
+        """
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+        self.timeout = timeout
+        self.validate_certs = validate_certs
+        self._http_request = http_request_func or http_request_safe
+
+    def _headers(self) -> Dict[str, str]:
+        """Return request headers including authorization."""
+        return {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[Dict[str, JSONTypes]] = None,
+    ) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
+        """Perform an API request.
+
+        :returns: Parsed JSON response and error message
+        """
+        url = f"{self.api_url}{path}"
+        body = json.dumps(payload) if payload is not None else None
+        response, error = self._http_request(
+            method=method,
+            url=url,
+            headers=self._headers(),
+            body=body,
+            timeout=self.timeout,
+            validate_certs=self.validate_certs,
+        )
+        if response is None:
+            return None, error
+        if response.status >= 400:
+            return None, error or response.body
+        if not response.body:
+            return {}, ""
+        data = response.json()
+        if isinstance(data, dict):
+            return data, ""
+        return {"data": data}, ""
+
+    def get(self, gist_id: str) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
+        """Retrieve a gist by id."""
+        return self._request("GET", f"/gists/{gist_id}")
+
+    def create(
+        self,
+        description: str,
+        public: bool,
+        files: Dict[str, str],
+    ) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
+        """Create a new gist."""
+        payload = {
+            "description": description,
+            "public": public,
+            "files": {name: {"content": content} for name, content in files.items()},
+        }
+        return self._request("POST", "/gists", payload)
+
+    def update(
+        self,
+        gist_id: str,
+        description: Optional[str],
+        public: Optional[bool],
+        files: Dict[str, str],
+    ) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
+        """Update an existing gist."""
+        payload: Dict[str, JSONTypes] = {
+            "files": {name: {"content": content} for name, content in files.items()},
+        }
+        if description is not None:
+            payload["description"] = description
+        if public is not None:
+            payload["public"] = public
+        return self._request("PATCH", f"/gists/{gist_id}", payload)
+
+    def delete(self, gist_id: str) -> Tuple[bool, str]:
+        """Delete a gist."""
+        response, error = self._http_request(
+            method="DELETE",
+            url=f"{self.api_url}/gists/{gist_id}",
+            headers=self._headers(),
+            timeout=self.timeout,
+            validate_certs=self.validate_certs,
+        )
+        if response is None:
+            return False, error
+        if response.status in (204, 404):
+            return True, ""
+        return False, error or response.body
+
+    @staticmethod
+    def extract_files(gist: Dict[str, JSONTypes]) -> Dict[str, str]:
+        """Extract file contents from a gist response."""
+        files = gist.get("files", {})
+        if not isinstance(files, dict):
+            return {}
+        extracted: Dict[str, str] = {}
+        for name, details in files.items():
+            if isinstance(details, dict):
+                extracted[name] = str(details.get("content", ""))
+        return extracted
+
+    @staticmethod
+    def files_match(existing: Dict[str, str], desired: Dict[str, str]) -> bool:
+        """Return True when desired file contents match the existing gist."""
+        return existing == desired
+
+    @staticmethod
+    def normalize_result(gist: Dict[str, JSONTypes]) -> Dict[str, JSONTypes]:
+        """Normalize gist API response for module return values."""
+        return {
+            "id": gist.get("id", ""),
+            "html_url": gist.get("html_url", ""),
+            "git_pull_url": gist.get("git_pull_url", ""),
+            "description": gist.get("description", ""),
+            "public": gist.get("public", False),
+            "files": GitHubGist.extract_files(gist),
+        }

--- a/plugins/plugin_utils/gitlab_snippet.py
+++ b/plugins/plugin_utils/gitlab_snippet.py
@@ -1,0 +1,189 @@
+"""GitLab Snippet API client."""
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+import json
+
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from .http_request import HttpResponse, http_request_safe
+
+
+JSONTypes = Union[bool, int, str, Dict[str, Any], list]  # type: ignore
+
+HttpRequestCallable = Callable[..., Tuple[Optional[HttpResponse], str]]
+
+
+class GitLabSnippet:
+    """Client for the GitLab Snippets REST API."""
+
+    def __init__(
+        self,
+        token: str,
+        api_url: str = "https://gitlab.com/api/v4",
+        timeout: int = 30,
+        validate_certs: bool = True,
+        http_request_func: Optional[HttpRequestCallable] = None,
+    ) -> None:
+        """Initialize the client."""
+        self.token = token
+        self.api_url = api_url.rstrip("/")
+        self.timeout = timeout
+        self.validate_certs = validate_certs
+        self._http_request = http_request_func or http_request_safe
+
+    def _headers(self) -> Dict[str, str]:
+        """Return request headers including authorization."""
+        return {
+            "PRIVATE-TOKEN": self.token,
+            "Content-Type": "application/json",
+        }
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[Dict[str, JSONTypes]] = None,
+    ) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
+        """Perform an API request."""
+        url = f"{self.api_url}{path}"
+        body = json.dumps(payload) if payload is not None else None
+        response, error = self._http_request(
+            method=method,
+            url=url,
+            headers=self._headers(),
+            body=body,
+            timeout=self.timeout,
+            validate_certs=self.validate_certs,
+        )
+        if response is None:
+            return None, error
+        if response.status >= 400:
+            return None, error or response.body
+        if not response.body:
+            return {}, ""
+        data = response.json()
+        if isinstance(data, dict):
+            return data, ""
+        return {"data": data}, ""
+
+    def _snippet_path(self, snippet_id: str, project_id: Optional[str]) -> str:
+        if project_id:
+            return f"/projects/{project_id}/snippets/{snippet_id}"
+        return f"/snippets/{snippet_id}"
+
+    def get(
+        self,
+        snippet_id: str,
+        project_id: Optional[str] = None,
+    ) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
+        """Retrieve a snippet by id."""
+        return self._request("GET", self._snippet_path(snippet_id, project_id))
+
+    def create(
+        self,
+        title: str,
+        description: str,
+        visibility: str,
+        files: Dict[str, str],
+        project_id: Optional[str] = None,
+    ) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
+        """Create a new snippet."""
+        file_entries: List[Dict[str, str]] = [
+            {"file_path": name, "content": content} for name, content in files.items()
+        ]
+        payload: Dict[str, JSONTypes] = {
+            "title": title,
+            "description": description,
+            "visibility": visibility,
+            "files": file_entries,
+        }
+        path = f"/projects/{project_id}/snippets" if project_id else "/snippets"
+        return self._request("POST", path, payload)
+
+    def update(
+        self,
+        snippet_id: str,
+        title: Optional[str],
+        description: Optional[str],
+        visibility: Optional[str],
+        files: Dict[str, str],
+        project_id: Optional[str] = None,
+    ) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
+        """Update an existing snippet."""
+        payload: Dict[str, JSONTypes] = {
+            "files": [
+                {"file_path": name, "content": content} for name, content in files.items()
+            ],
+        }
+        if title is not None:
+            payload["title"] = title
+        if description is not None:
+            payload["description"] = description
+        if visibility is not None:
+            payload["visibility"] = visibility
+        return self._request(
+            "PUT",
+            self._snippet_path(snippet_id, project_id),
+            payload,
+        )
+
+    def delete(
+        self,
+        snippet_id: str,
+        project_id: Optional[str] = None,
+    ) -> Tuple[bool, str]:
+        """Delete a snippet."""
+        response, error = self._http_request(
+            method="DELETE",
+            url=f"{self.api_url}{self._snippet_path(snippet_id, project_id)}",
+            headers=self._headers(),
+            timeout=self.timeout,
+            validate_certs=self.validate_certs,
+        )
+        if response is None:
+            return False, error
+        if response.status in (204, 404):
+            return True, ""
+        return False, error or response.body
+
+    @staticmethod
+    def extract_files(snippet: Dict[str, JSONTypes]) -> Dict[str, str]:
+        """Extract file contents from a snippet response."""
+        files = snippet.get("files", {})
+        if isinstance(files, dict):
+            extracted: Dict[str, str] = {}
+            for name, details in files.items():
+                if isinstance(details, dict):
+                    extracted[name] = str(details.get("content", ""))
+                else:
+                    extracted[name] = str(details)
+            return extracted
+
+        file_name = snippet.get("file_name")
+        if file_name:
+            return {str(file_name): str(snippet.get("content", ""))}
+        return {}
+
+    @staticmethod
+    def files_match(existing: Dict[str, str], desired: Dict[str, str]) -> bool:
+        """Return True when desired file contents match the existing snippet."""
+        return existing == desired
+
+    @staticmethod
+    def normalize_result(snippet: Dict[str, JSONTypes]) -> Dict[str, JSONTypes]:
+        """Normalize snippet API response for module return values."""
+        web_url = snippet.get("web_url", "")
+        return {
+            "id": snippet.get("id", ""),
+            "html_url": web_url,
+            "description": snippet.get("description", ""),
+            "title": snippet.get("title", ""),
+            "visibility": snippet.get("visibility", ""),
+            "files": GitLabSnippet.extract_files(snippet),
+        }

--- a/plugins/plugin_utils/gitlab_snippet.py
+++ b/plugins/plugin_utils/gitlab_snippet.py
@@ -117,9 +117,7 @@ class GitLabSnippet:
     ) -> Tuple[Optional[Dict[str, JSONTypes]], str]:
         """Update an existing snippet."""
         payload: Dict[str, JSONTypes] = {
-            "files": [
-                {"file_path": name, "content": content} for name, content in files.items()
-            ],
+            "files": [{"file_path": name, "content": content} for name, content in files.items()],
         }
         if title is not None:
             payload["title"] = title

--- a/plugins/plugin_utils/http_request.py
+++ b/plugins/plugin_utils/http_request.py
@@ -98,13 +98,16 @@ def http_request_safe(
     """
     del validate_certs  # urllib uses system trust store; reserved for future use
     try:
-        return http_request(
-            method=method,
-            url=url,
-            headers=headers,
-            body=body,
-            timeout=timeout,
-        ), ""
+        return (
+            http_request(
+                method=method,
+                url=url,
+                headers=headers,
+                body=body,
+                timeout=timeout,
+            ),
+            "",
+        )
     except HTTPError as exc:
         error_body = exc.read().decode("utf-8") if exc.fp else ""
         return HttpResponse(status=exc.code, body=error_body), error_body or str(exc)

--- a/plugins/plugin_utils/http_request.py
+++ b/plugins/plugin_utils/http_request.py
@@ -1,0 +1,112 @@
+"""HTTP helpers for gist and snippet API clients."""
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+import json
+
+from typing import Any, Dict, Optional, Tuple, TypeVar, Union
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+JSONTypes = Union[bool, int, str, Dict[str, Any], list]  # type: ignore
+
+T = TypeVar("T", bound="HttpResponse")  # pylint: disable=invalid-name, useless-suppression
+
+
+class HttpResponse:
+    """Normalized HTTP response."""
+
+    def __init__(
+        self: T,
+        status: int,
+        body: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Initialize the response.
+
+        :param status: The HTTP status code
+        :param body: The response body
+        :param headers: Optional response headers
+        """
+        self.status = status
+        self.body = body
+        self.headers = headers or {}
+
+    def json(self: T) -> JSONTypes:
+        """Parse the response body as JSON.
+
+        :returns: The parsed JSON payload
+        """
+        if not self.body:
+            return {}
+        return json.loads(self.body)
+
+
+def http_request(
+    method: str,
+    url: str,
+    headers: Optional[Dict[str, str]] = None,
+    body: Optional[Union[str, bytes]] = None,
+    timeout: int = 30,
+    validate_certs: bool = True,
+) -> HttpResponse:
+    """Perform an HTTP request.
+
+    :param method: The HTTP method
+    :param url: The request URL
+    :param headers: Optional request headers
+    :param body: Optional request body
+    :param timeout: Request timeout in seconds
+    :param validate_certs: Whether to validate TLS certificates
+    :returns: The HTTP response
+    :raises HTTPError: If the server returns an error status
+    :raises URLError: If the request cannot be completed
+    """
+    request_headers = dict(headers or {})
+    data: Optional[bytes] = None
+    if body is not None:
+        data = body.encode("utf-8") if isinstance(body, str) else body
+
+    request = Request(url=url, data=data, headers=request_headers, method=method.upper())
+    with urlopen(request, timeout=timeout) as response:  # noqa: S310
+        response_body = response.read().decode("utf-8")
+        response_headers = {key.lower(): value for key, value in response.headers.items()}
+        return HttpResponse(
+            status=response.status,
+            body=response_body,
+            headers=response_headers,
+        )
+
+
+def http_request_safe(
+    method: str,
+    url: str,
+    headers: Optional[Dict[str, str]] = None,
+    body: Optional[Union[str, bytes]] = None,
+    timeout: int = 30,
+    validate_certs: bool = True,
+) -> Tuple[Optional[HttpResponse], str]:
+    """Perform an HTTP request and return errors instead of raising.
+
+    :returns: A tuple of response and error message
+    """
+    del validate_certs  # urllib uses system trust store; reserved for future use
+    try:
+        return http_request(
+            method=method,
+            url=url,
+            headers=headers,
+            body=body,
+            timeout=timeout,
+        ), ""
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8") if exc.fp else ""
+        return HttpResponse(status=exc.code, body=error_body), error_body or str(exc)
+    except URLError as exc:
+        return None, str(exc.reason)

--- a/tests/unit/test_gist_clients.py
+++ b/tests/unit/test_gist_clients.py
@@ -51,7 +51,6 @@ def test_github_create_gist() -> None:
 
 def test_github_update_is_idempotent() -> None:
     """Test gist file comparison for idempotency."""
-
     existing = {"files": {"report.txt": {"content": "same"}}}
     assert GitHubGist.files_match(
         GitHubGist.extract_files(existing),

--- a/tests/unit/test_gist_clients.py
+++ b/tests/unit/test_gist_clients.py
@@ -1,0 +1,98 @@
+"""Unit tests for gist API clients."""
+
+from __future__ import absolute_import, division, print_function
+
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+# pylint: enable=invalid-name
+
+import json
+
+from typing import Optional, Tuple, Union
+
+from ansible_collections.ansible.scm.plugins.plugin_utils.github_gist import GitHubGist
+from ansible_collections.ansible.scm.plugins.plugin_utils.gitlab_snippet import GitLabSnippet
+from ansible_collections.ansible.scm.plugins.plugin_utils.http_request import HttpResponse
+
+
+def _mock_response(status: int, payload: Union[dict, list]) -> Tuple[Optional[HttpResponse], str]:
+    return HttpResponse(status=status, body=json.dumps(payload)), ""
+
+
+def test_github_create_gist() -> None:
+    """Test creating a GitHub gist."""
+
+    def mock_request(method, url, headers, body=None, timeout=30, validate_certs=True):
+        del headers, timeout, validate_certs
+        assert method == "POST"
+        assert url.endswith("/gists")
+        payload = json.loads(body or "{}")
+        assert payload["files"]["report.txt"]["content"] == "hello"
+        return _mock_response(
+            201,
+            {
+                "id": "abc123",
+                "html_url": "https://gist.github.com/abc123",
+                "description": "test gist",
+                "public": False,
+                "files": {"report.txt": {"content": "hello"}},
+            },
+        )
+
+    client = GitHubGist(token="secret", http_request_func=mock_request)
+    gist, error = client.create("test gist", False, {"report.txt": "hello"})
+    assert error == ""
+    assert gist is not None
+    normalized = GitHubGist.normalize_result(gist)
+    assert normalized["id"] == "abc123"
+    assert normalized["files"]["report.txt"] == "hello"
+
+
+def test_github_update_is_idempotent() -> None:
+    """Test gist file comparison for idempotency."""
+
+    existing = {"files": {"report.txt": {"content": "same"}}}
+    assert GitHubGist.files_match(
+        GitHubGist.extract_files(existing),
+        {"report.txt": "same"},
+    )
+    assert not GitHubGist.files_match(
+        GitHubGist.extract_files(existing),
+        {"report.txt": "different"},
+    )
+
+
+def test_gitlab_create_snippet() -> None:
+    """Test creating a GitLab snippet."""
+
+    def mock_request(method, url, headers, body=None, timeout=30, validate_certs=True):
+        del headers, timeout, validate_certs
+        assert method == "POST"
+        assert url.endswith("/snippets")
+        payload = json.loads(body or "{}")
+        assert payload["files"][0]["file_path"] == "report.txt"
+        return _mock_response(
+            201,
+            {
+                "id": 42,
+                "web_url": "https://gitlab.com/snippets/42",
+                "description": "test snippet",
+                "title": "report",
+                "visibility": "private",
+                "files": {"report.txt": {"content": "hello"}},
+            },
+        )
+
+    client = GitLabSnippet(token="secret", http_request_func=mock_request)
+    snippet, error = client.create(
+        "report",
+        "test snippet",
+        "private",
+        {"report.txt": "hello"},
+    )
+    assert error == ""
+    assert snippet is not None
+    normalized = GitLabSnippet.normalize_result(snippet)
+    assert normalized["id"] == 42
+    assert normalized["html_url"] == "https://gitlab.com/snippets/42"

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -14,6 +14,12 @@ import pytest
 from ansible.errors import AnsibleActionFail
 
 # pylint: disable=import-error
+from ansible_collections.ansible.scm.plugins.action.gist_publish import (
+    ActionModule as GistPublishActionModule,
+)
+from ansible_collections.ansible.scm.plugins.action.gist_retrieve import (
+    ActionModule as GistRetrieveActionModule,
+)
 from ansible_collections.ansible.scm.plugins.action.git_publish import (
     ActionModule as GitPublishActionModule,
 )
@@ -26,12 +32,22 @@ from .definitions import ActionModuleInit
 
 @pytest.mark.parametrize(
     "module",
-    (GitRetrieveActionModule, GitPublishActionModule),
-    ids=("git_retrieve", "git_publish"),
+    (
+        GitRetrieveActionModule,
+        GitPublishActionModule,
+        GistRetrieveActionModule,
+        GistPublishActionModule,
+    ),
+    ids=("git_retrieve", "git_publish", "gist_retrieve", "gist_publish"),
 )
 def test_fail_argspec(
     action_init: ActionModuleInit,
-    module: Union[GitPublishActionModule, GitRetrieveActionModule],
+    module: Union[
+        GitPublishActionModule,
+        GitRetrieveActionModule,
+        GistPublishActionModule,
+        GistRetrieveActionModule,
+    ],
 ) -> None:
     """Test an argspec failure.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
```
cd /Users/../playbooks
export GITHUB_TOKEN=your_token_here
export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES   # macOS + conda
ansible-playbook ansible_scm.yaml -i inventory
```

Playbook - 
Publish
```
- name: Publish Meraki report to gist
  ansible.scm.gist_publish:
    provider: github
    token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
    description: "Meraki admin report"
    public: false
    files:
      report.json:
        content: "{{ meraki_report | to_nice_json }}"
      summary.txt:
        content: "{{ summary }}"
    gist_id: "{{ existing_gist_id | default(omit) }}"  # update if set
  register: gist
```
Retrive 
```
- name: Load baseline from gist
  ansible.scm.gist_retrieve:
    provider: github
    token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
    gist_id: abc123
  register: gist
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
