### PR TITLE
git_publish: add update_strategy option to reconcile with remote before pushing

### DIFF
--- a/changelogs/fragments/285-git-publish-update-strategy.yaml
+++ b/changelogs/fragments/285-git-publish-update-strategy.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - git_publish - add ``update_strategy`` option to optionally rebase or merge with
+    the remote branch before pushing, so a remote that advances between clone and
+    publish no longer forces a hard failure
+    (https://github.com/ansible-collections/ansible.scm/issues/285).

--- a/docs/ansible.scm.git_publish_module.rst
+++ b/docs/ansible.scm.git_publish_module.rst
@@ -255,6 +255,31 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>update_strategy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.3.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>fail</b>&nbsp;&larr;</div></li>
+                                    <li>rebase</li>
+                                    <li>merge</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Strategy to use when the remote branch has advanced since clone.</div>
+                        <div><code>fail</code> preserves the current behavior; the push fails on non-fast-forward.</div>
+                        <div><code>rebase</code> fetches the remote branch and rebases the local commit on top before pushing.</div>
+                        <div><code>merge</code> fetches the remote branch and merges it into the local branch before pushing.</div>
+                        <div>When <code>rebase</code> or <code>merge</code> hits a real conflict, the in-progress operation is aborted and the task fails so the working tree is left clean.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>user</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/extensions/molecule/integration_remote_advanced/molecule.yml
+++ b/extensions/molecule/integration_remote_advanced/molecule.yml
@@ -1,0 +1,19 @@
+platforms:
+  - name: na
+
+provisioner:
+  name: ansible
+  playbooks:
+    cleanup: ../resources/playbooks/noop.yml
+    converge: ../resources/playbooks/converge.yml
+    destroy: ../resources/playbooks/noop.yml
+    prepare: ../resources/playbooks/noop.yml
+  config_options:
+    defaults:
+      collections_path: ${ANSIBLE_COLLECTIONS_PATH}
+scenario:
+  test_sequence:
+    - prepare
+    - converge
+  destroy_sequence:
+    - destroy

--- a/plugins/action/git_publish.py
+++ b/plugins/action/git_publish.py
@@ -233,6 +233,105 @@ class ActionModule(GitBase):
         )
         self._run_command(command=command)
 
+    def _reconcile_remote(self: T) -> None:
+        """Reconcile local branch with the remote before pushing.
+
+        Honors the ``update_strategy`` option:
+        - ``fail`` (default): no-op, preserves prior behavior.
+        - ``rebase``: fetch origin and rebase local commit on top.
+        - ``merge``: fetch origin and merge origin into local branch.
+
+        On a real conflict during rebase/merge the in-progress operation is
+        aborted so the working tree is left clean and the task fails with the
+        original git error preserved in the result output. The token auth
+        header is only applied for https remotes, mirroring ``_push``.
+        """
+        strategy = self._task.args.get("update_strategy", "fail")
+        if strategy == "fail":
+            return
+
+        command_parts = list(self._base_command)
+        command_parts.extend(["rev-parse", "--abbrev-ref", "HEAD"])
+        command = Command(
+            command_parts=command_parts,
+            fail_msg="Failed to determine the current branch for reconciliation.",
+            env=self._env,
+        )
+        self._run_command(command=command)
+        if self._result.failed:
+            return
+        branch = command.stdout.strip()
+
+        command_parts = list(self._base_command)
+        command_parts.extend(["remote", "-v"])
+        command = Command(
+            command_parts=command_parts,
+            fail_msg="Failed to get remote for reconciliation.",
+            env=self._env,
+        )
+        self._run_command(command=command)
+        if self._result.failed:
+            return
+        try:
+            push_line = next(
+                line for line in command.stdout_lines if "push" in line and "origin" in line
+            )
+        except StopIteration:
+            self._result.failed = True
+            self._result.msg = "Failed to find the origin remote"
+            return
+
+        token = self._task.args.get("token")
+        no_log = {}
+        command_parts = list(self._base_command)
+        if token is not None and "https" in push_line:
+            token_base64, command_parameters = self._git_auth_header(token)
+            command_parts.extend(command_parameters)
+            no_log[token_base64] = "<TOKEN>"
+        command_parts.extend(["fetch", "origin", branch])
+        command = Command(
+            command_parts=command_parts,
+            fail_msg=f"Failed to fetch origin/{branch} for reconciliation.",
+            no_log=no_log,
+            env=self._env,
+        )
+        self._run_command(command=command)
+        if self._result.failed:
+            return
+
+        self._apply_update_strategy(strategy=strategy, branch=branch)
+
+    def _apply_update_strategy(self: T, strategy: str, branch: str) -> None:
+        """Run the chosen rebase or merge step, aborting cleanly on conflict.
+
+        :param strategy: ``rebase`` or ``merge``.
+        :param branch: The local branch name; the remote ref is ``origin/<branch>``.
+        """
+        verb_args = {
+            "rebase": ["rebase", f"origin/{branch}"],
+            "merge": ["merge", "--no-edit", f"origin/{branch}"],
+        }[strategy]
+        command_parts = list(self._base_command)
+        command_parts.extend(verb_args)
+        command = Command(
+            command_parts=command_parts,
+            fail_msg=f"Failed to {strategy} onto origin/{branch}.",
+            env=self._env,
+        )
+        self._run_command(command=command)
+        if not self._result.failed:
+            return
+
+        # Preserve the original failure message; only run abort for cleanup.
+        abort_parts = list(self._base_command)
+        abort_parts.extend([strategy, "--abort"])
+        abort = Command(
+            command_parts=abort_parts,
+            fail_msg=f"Failed to abort the in-progress {strategy}.",
+            env=self._env,
+        )
+        self._run_command(command=abort, ignore_errors=True)
+
     def _push(self: T) -> None:
         """Push the commit to the origin."""
         command_parts = list(self._base_command)
@@ -325,7 +424,7 @@ class ActionModule(GitBase):
             if self._task.args.get("tag"):
                 steps.append(self._tag)
 
-            steps.extend([self._push, self._remove_repo])
+            steps.extend([self._reconcile_remote, self._push, self._remove_repo])
 
             for step in steps:
                 step()

--- a/plugins/modules/git_publish.py
+++ b/plugins/modules/git_publish.py
@@ -72,6 +72,21 @@ options:
       message:
         description: Specify tag message
         type: str
+  update_strategy:
+    description:
+      - Strategy to use when the remote branch has advanced since clone.
+      - C(fail) preserves the current behavior; the push fails on non-fast-forward.
+      - C(rebase) fetches the remote branch and rebases the local commit on top before pushing.
+      - C(merge) fetches the remote branch and merges it into the local branch before pushing.
+      - When C(rebase) or C(merge) hits a real conflict, the in-progress operation is
+        aborted and the task fails so the working tree is left clean.
+    type: str
+    choices:
+      - fail
+      - rebase
+      - merge
+    default: fail
+    version_added: "3.3.0"
   user:
     description:
       - Details for the user to be used for the commit

--- a/tests/integration/targets/remote_advanced/tasks/main.yaml
+++ b/tests/integration/targets/remote_advanced/tasks/main.yaml
@@ -1,0 +1,235 @@
+- name: Create a working directory for the bare-remote scenarios
+  ansible.builtin.tempfile:
+    state: directory
+    prefix: ansible-scm-remote-advanced-
+  register: workdir
+
+# region rebase: remote advances, local rebases on top, push succeeds
+
+- name: Initialize a bare repository to act as the rebase remote
+  ansible.builtin.command: # noqa: command-instead-of-module
+    cmd: git init --bare {{ workdir.path }}/rebase.git
+  changed_when: true
+
+- name: Seed the rebase remote with an initial commit on main
+  ansible.builtin.shell: |
+    set -eu
+    cd "{{ workdir.path }}"
+    git clone rebase.git seed
+    cd seed
+    git -c user.email=seed@example.com -c user.name=seed commit \
+      --allow-empty -m "initial"
+    git branch -M main
+    git push origin main
+  changed_when: true
+
+- name: Clone the rebase remote into the local working copy
+  ansible.builtin.git:
+    repo: "{{ workdir.path }}/rebase.git"
+    dest: "{{ workdir.path }}/rebase_local"
+    version: main
+
+- name: Advance the rebase remote from a separate clone
+  ansible.builtin.shell: |
+    set -eu
+    cd "{{ workdir.path }}"
+    git clone rebase.git rebase_other
+    cd rebase_other
+    git config user.email other@example.com
+    git config user.name other
+    echo "remote update" > remote-only.txt
+    git add remote-only.txt
+    git commit -m "advance remote"
+    git push origin main
+  changed_when: true
+
+- name: Add a local change to publish
+  ansible.builtin.copy:
+    content: "local change"
+    dest: "{{ workdir.path }}/rebase_local/local-change.txt"
+    mode: "0644"
+
+- name: Publish with update_strategy=rebase
+  ansible.scm.git_publish:
+    path: "{{ workdir.path }}/rebase_local"
+    update_strategy: rebase
+    user:
+      name: publisher
+      email: publisher@example.com
+    remove: false
+  register: rebase_result
+
+- name: Confirm the rebase publish succeeded
+  ansible.builtin.assert:
+    that:
+      - not rebase_result.failed
+      - "'Successfully published' in rebase_result.msg"
+
+- name: Inspect the rebase remote log
+  ansible.builtin.command: # noqa: command-instead-of-module
+    cmd: git -C {{ workdir.path }}/rebase.git log --pretty=%s main
+  register: rebase_log
+  changed_when: false
+
+- name: Assert the rebase remote contains both the divergent and the published commits
+  ansible.builtin.assert:
+    that:
+      - "'advance remote' in rebase_log.stdout"
+      - "'Updates made by ansible' in rebase_log.stdout"
+
+# endregion
+
+# region merge: remote advances, local merges, push succeeds
+
+- name: Initialize a bare repository to act as the merge remote
+  ansible.builtin.command: # noqa: command-instead-of-module
+    cmd: git init --bare {{ workdir.path }}/merge.git
+  changed_when: true
+
+- name: Seed the merge remote with an initial commit on main
+  ansible.builtin.shell: |
+    set -eu
+    cd "{{ workdir.path }}"
+    git clone merge.git merge_seed
+    cd merge_seed
+    git -c user.email=seed@example.com -c user.name=seed commit \
+      --allow-empty -m "initial"
+    git branch -M main
+    git push origin main
+  changed_when: true
+
+- name: Clone the merge remote into the local working copy
+  ansible.builtin.git:
+    repo: "{{ workdir.path }}/merge.git"
+    dest: "{{ workdir.path }}/merge_local"
+    version: main
+
+- name: Advance the merge remote from a separate clone
+  ansible.builtin.shell: |
+    set -eu
+    cd "{{ workdir.path }}"
+    git clone merge.git merge_other
+    cd merge_other
+    git config user.email other@example.com
+    git config user.name other
+    echo "remote update" > remote-only.txt
+    git add remote-only.txt
+    git commit -m "advance remote"
+    git push origin main
+  changed_when: true
+
+- name: Add a local change to publish
+  ansible.builtin.copy:
+    content: "local change"
+    dest: "{{ workdir.path }}/merge_local/local-change.txt"
+    mode: "0644"
+
+- name: Publish with update_strategy=merge
+  ansible.scm.git_publish:
+    path: "{{ workdir.path }}/merge_local"
+    update_strategy: merge
+    user:
+      name: publisher
+      email: publisher@example.com
+    remove: false
+  register: merge_result
+
+- name: Confirm the merge publish succeeded
+  ansible.builtin.assert:
+    that:
+      - not merge_result.failed
+      - "'Successfully published' in merge_result.msg"
+
+- name: Inspect the merge remote log
+  ansible.builtin.command: # noqa: command-instead-of-module
+    cmd: git -C {{ workdir.path }}/merge.git log --pretty=%s main
+  register: merge_log
+  changed_when: false
+
+- name: Assert the merge remote contains the divergent commit and a merge commit
+  ansible.builtin.assert:
+    that:
+      - "'advance remote' in merge_log.stdout"
+      - "'Updates made by ansible' in merge_log.stdout"
+      - "'Merge remote-tracking branch' in merge_log.stdout"
+
+# endregion
+
+# region conflict: both sides edit the same file; rebase must abort and fail
+
+- name: Initialize a bare repository to act as the conflict remote
+  ansible.builtin.command: # noqa: command-instead-of-module
+    cmd: git init --bare {{ workdir.path }}/conflict.git
+  changed_when: true
+
+- name: Seed the conflict remote with a shared file on main
+  ansible.builtin.shell: |
+    set -eu
+    cd "{{ workdir.path }}"
+    git clone conflict.git conflict_seed
+    cd conflict_seed
+    echo "line one" > shared.txt
+    git add shared.txt
+    git -c user.email=seed@example.com -c user.name=seed commit -m "initial"
+    git branch -M main
+    git push origin main
+  changed_when: true
+
+- name: Clone the conflict remote into the local working copy
+  ansible.builtin.git:
+    repo: "{{ workdir.path }}/conflict.git"
+    dest: "{{ workdir.path }}/conflict_local"
+    version: main
+
+- name: Advance the conflict remote with an edit to shared.txt
+  ansible.builtin.shell: |
+    set -eu
+    cd "{{ workdir.path }}"
+    git clone conflict.git conflict_other
+    cd conflict_other
+    git config user.email other@example.com
+    git config user.name other
+    echo "remote version" > shared.txt
+    git commit -am "remote edit"
+    git push origin main
+  changed_when: true
+
+- name: Stage a conflicting local edit to shared.txt
+  ansible.builtin.copy:
+    content: "local version"
+    dest: "{{ workdir.path }}/conflict_local/shared.txt"
+    mode: "0644"
+
+- name: Publish with update_strategy=rebase (should fail on conflict)
+  ansible.scm.git_publish:
+    path: "{{ workdir.path }}/conflict_local"
+    update_strategy: rebase
+    user:
+      name: publisher
+      email: publisher@example.com
+    remove: false
+  register: conflict_result
+  ignore_errors: true
+
+- name: Confirm the conflict publish failed
+  ansible.builtin.assert:
+    that:
+      - conflict_result.failed
+      - "'rebase' in conflict_result.msg"
+
+- name: Check that the working tree has no in-progress rebase state
+  ansible.builtin.stat:
+    path: "{{ workdir.path }}/conflict_local/.git/rebase-merge"
+  register: rebase_state
+
+- name: Assert the rebase was aborted cleanly
+  ansible.builtin.assert:
+    that:
+      - not rebase_state.stat.exists
+
+# endregion
+
+- name: Clean up the working directory
+  ansible.builtin.file:
+    path: "{{ workdir.path }}"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add an `update_strategy` option to `git_publish` so that when the remote branch
has advanced between clone and publish, the action can transparently rebase or
merge the remote changes before pushing instead of hard-failing on
non-fast-forward.

The default value `fail` preserves the prior behavior. Setting `rebase` (the
common case) fetches `origin/<current-branch>` and rebases the local commit on
top; `merge` does a `git merge --no-edit` instead. On a genuine file conflict,
the in-progress rebase or merge is aborted (`--abort`) so the working tree is
left clean and the task fails with the original git error preserved.

Fixes #285.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.scm.git_publish

##### ADDITIONAL INFORMATION
Implementation notes:

- New `_reconcile_remote` method models the existing `_pull_upstream` pattern
  from `plugins/action/git_retrieve.py`. It runs `git rev-parse --abbrev-ref HEAD`
  to discover the current branch (the module pushes to whatever HEAD is, matching
  the existing module note: "The push will always be to the current branch"),
  then `git remote -v` to decide whether the token auth header applies —
  mirroring `_push` so SSH remotes never get an HTTP header.
- The rebase and merge paths share an `_apply_update_strategy` helper that also
  handles the `--abort` cleanup so the same code runs for both.
- Three new integration scenarios cover the rebase, merge, and conflict paths,
  all using local bare repositories so no network or `GITHUB_TOKEN` is required
  to run the new tests.
- One non-fix carry-forward worth flagging for a follow-up: the "build
  `command_parts` + optionally splice token auth header" pattern now appears
  three times (`_push`, `_pull_upstream`, `_reconcile_remote`). A
  `GitBase._token_aware_command_parts(token, remote_url)` helper would
  centralize the `"https" in remote` gate, but pulling that in here would
  expand a bug-fix into a touch-all-modules refactor. Happy to do it as a
  separate PR if maintainers want.

```paste below

```
